### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -16,7 +16,7 @@ import Branch
         fatalError("rootViewController cannot be casted to FlutterViewController")
     }
     
-    let eventChannel = FlutterEventChannel(name: "flutter_branch_io/event", binaryMessenger: controller)
+    let eventChannel = FlutterEventChannel(name: "flutter_branch_io/event", binaryMessenger: controller.binaryMessenger)
     
     eventChannel.setStreamHandler(self)
     


### PR DESCRIPTION
Example does not compile on iOS, argument type 'FlutterViewController' does not conform to expected type 'FlutterBinaryMessenger.

https://github.com/flutter/flutter/issues/35773
https://github.com/flutter/flutter/issues/35945